### PR TITLE
RDK-55906: [socprov.log] Data Collection Through T2 Events For socprov.log

### DIFF
--- a/PerformanceMetrics/SyslogOutput.cpp
+++ b/PerformanceMetrics/SyslogOutput.cpp
@@ -261,7 +261,6 @@ public:
         , _didLogLaunchMetrics(false)
         , _lastLoggedApp()
         {
-            Utils::Telemetry::init();
         }
     ~SysLogOuput() override
     {


### PR DESCRIPTION
Reason for change: removing excess t2 initialization calls
Test Procedure: see Jira ticket
Risks: Low
Priority: Medium